### PR TITLE
perf: Rearrange layers to speed up docker build

### DIFF
--- a/dockerfile
+++ b/dockerfile
@@ -4,6 +4,9 @@ FROM python:3.12.1-slim
 # Set the working directory in the container
 WORKDIR /app
 
+# Install ffmpeg and clean up apt cache to reduce image size
+RUN apt-get update && apt-get install -y ffmpeg && rm -rf /var/lib/apt/lists/*
+
 # Copy only the requirements files first to leverage Docker cache
 COPY ./core/requirements.txt ./core/requirements.txt
 COPY requirements.txt requirements.txt
@@ -14,9 +17,6 @@ RUN pip install --no-cache-dir -r ./core/requirements.txt \
 
 # Copy the rest of the application code
 COPY . .
-
-# Install ffmpeg and clean up apt cache to reduce image size
-RUN apt-get update && apt-get install -y ffmpeg && rm -rf /var/lib/apt/lists/*
 
 # Run app.py when the container launches
 CMD ["python", "app.py"]


### PR DESCRIPTION
Moves the `apt install` layer in the Dockerfile up to allow it to better leverage Docker's cache (see https://docs.docker.com/build/cache/)